### PR TITLE
#18 Fixing invoke omegat pull source on pull transifex workflow

### DIFF
--- a/.github/workflows/pull-transifex.yml
+++ b/.github/workflows/pull-transifex.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           workflow: Pull source
           repo: ${{ github.repository_owner }}/OSGeoLive-doc-omegat
+          ref: master
           token: ${{ secrets.PERSONAL_TOKEN }}
 
   update-omegat_ja:


### PR DESCRIPTION
明示的に `omegat` 側のブランチ名(`master`)を指定。